### PR TITLE
OSOE-852: Change NuGet metadata to use license expression

### DIFF
--- a/Lombiq.Npm.Targets.csproj
+++ b/Lombiq.Npm.Targets.csproj
@@ -15,11 +15,10 @@
     <PackageTags>Lombiq;NPM;Node.js;MSBuild</PackageTags>
     <RepositoryUrl>https://github.com/Lombiq/NPM-Targets</RepositoryUrl>
     <PackageProjectUrl>https://github.com/Lombiq/NPM-Targets</PackageProjectUrl>
-    <PackageLicenseFile>License.md</PackageLicenseFile>
+    <PackageLicenseExpression>BSD-3-Clause</PackageLicenseExpression>
   </PropertyGroup>
 
   <ItemGroup>
-    <None Include="License.md" Pack="true" PackagePath="" />
     <None Include="Readme.md" />
     <None Include="NuGetIcon.png" Pack="true" PackagePath="" />
     <None Include="build/**" Pack="true" PackagePath="build/" />


### PR DESCRIPTION
[OSOE-852](https://lombiq.atlassian.net/browse/OSOE-852)

[OSOE-852]: https://lombiq.atlassian.net/browse/OSOE-852?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ